### PR TITLE
Custom OpenIdConnectEvents

### DIFF
--- a/src/EsiaEvents.cs
+++ b/src/EsiaEvents.cs
@@ -52,8 +52,6 @@ namespace AISGorod.AspNetCore.Authentication.Esia
             pm.Parameters.Add("timestamp", now.ToString("yyyy.MM.dd HH:mm:ss") + " " + now.ToString("zzz").Replace(":", ""));
             pm.State = Guid.NewGuid().ToString();
 
-            AddAdditionalParametersForReceivingAccessCode(pm.Parameters);
-            
             // get data for sign
             var scope = pm.Parameters["scope"];
             var timestamp = pm.Parameters["timestamp"];
@@ -63,8 +61,7 @@ namespace AISGorod.AspNetCore.Authentication.Esia
             // set clientSecret
             pm.ClientSecret = EsiaExtensions.SignData(EsiaSigner, EsiaOptions, scope, timestamp, clientId, state);
 
-            // ok result
-            return Task.CompletedTask;
+            return AddAdditionalParametersForReceivingAccessCode(pm.Parameters);
         }
 
         /// <summary>

--- a/src/EsiaExtensions.cs
+++ b/src/EsiaExtensions.cs
@@ -4,7 +4,6 @@ using Microsoft.AspNetCore.Authentication.OpenIdConnect;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Options;
 using System;
-using System.Security.Cryptography.Pkcs;
 using System.Text;
 
 namespace Microsoft.Extensions.DependencyInjection
@@ -18,13 +17,33 @@ namespace Microsoft.Extensions.DependencyInjection
         public static AuthenticationBuilder AddEsia(this AuthenticationBuilder builder)
             => builder.AddEsia(EsiaDefaults.AuthenticationScheme, _ => { });
 
+        public static AuthenticationBuilder AddEsia<TEsiaEvents>(this AuthenticationBuilder builder)
+            where TEsiaEvents : EsiaEvents
+            => builder.AddEsia<TEsiaEvents>(EsiaDefaults.AuthenticationScheme, _ => { });
+
         public static AuthenticationBuilder AddEsia(this AuthenticationBuilder builder, Action<EsiaOptions> configureOptions)
             => builder.AddEsia(EsiaDefaults.AuthenticationScheme, configureOptions);
+
+        public static AuthenticationBuilder AddEsia<TEsiaEvents>(this AuthenticationBuilder builder, Action<EsiaOptions> configureOptions)
+            where TEsiaEvents : EsiaEvents
+            => builder.AddEsia<TEsiaEvents>(EsiaDefaults.AuthenticationScheme, configureOptions);
 
         public static AuthenticationBuilder AddEsia(this AuthenticationBuilder builder, string authenticationScheme, Action<EsiaOptions> configureOptions)
             => builder.AddEsia(authenticationScheme, EsiaDefaults.DisplayName, configureOptions);
 
+        public static AuthenticationBuilder AddEsia<TEsiaEvents>(this AuthenticationBuilder builder, string authenticationScheme, Action<EsiaOptions> configureOptions)
+            where TEsiaEvents : EsiaEvents
+            => builder.AddEsia<TEsiaEvents>(authenticationScheme, EsiaDefaults.DisplayName, configureOptions);
+
         public static AuthenticationBuilder AddEsia(this AuthenticationBuilder builder, string authenticationScheme, string displayName, Action<EsiaOptions> configureOptions)
+            => builder.AddEsia<EsiaEvents>(authenticationScheme, displayName, configureOptions);
+
+        public static AuthenticationBuilder AddEsia<TEsiaEvents>(
+            this AuthenticationBuilder builder,
+            string authenticationScheme,
+            string displayName,
+            Action<EsiaOptions> configureOptions)
+            where TEsiaEvents : EsiaEvents
         {
             var esiaOptions = new EsiaOptions();
             configureOptions(esiaOptions);
@@ -34,13 +53,13 @@ namespace Microsoft.Extensions.DependencyInjection
             // register new services
             builder.Services.AddSingleton(esiaOptions);
             builder.Services.AddSingleton(esiaEnvironment);
-            builder.Services.AddSingleton<EsiaEvents>();
+            builder.Services.AddSingleton<TEsiaEvents>();
             builder.Services.AddSingleton<OpenIdConnectOptionsBuilder>();
             builder.Services.AddTransient<IEsiaRestService, EsiaRestService>();
             builder.Services.TryAddEnumerable(ServiceDescriptor.Singleton<IPostConfigureOptions<OpenIdConnectOptions>, OpenIdConnectPostConfigureOptions>());
 
             var configBuilder = new OpenIdConnectOptionsBuilder(esiaOptions, esiaEnvironment);
-            return builder.AddRemoteScheme<OpenIdConnectOptions, EsiaHandler>(authenticationScheme, displayName, configBuilder.BuildAction());
+            return builder.AddRemoteScheme<OpenIdConnectOptions, EsiaHandler>(authenticationScheme, displayName, configBuilder.BuildAction<TEsiaEvents>());
         }
 #pragma warning restore CS1591 // Missing XML comment for publicly visible type or member
     }

--- a/src/EsiaExtensions.cs
+++ b/src/EsiaExtensions.cs
@@ -18,21 +18,21 @@ namespace Microsoft.Extensions.DependencyInjection
             => builder.AddEsia(EsiaDefaults.AuthenticationScheme, _ => { });
 
         public static AuthenticationBuilder AddEsia<TEsiaEvents>(this AuthenticationBuilder builder)
-            where TEsiaEvents : EsiaEvents
+            where TEsiaEvents : OpenIdConnectEvents
             => builder.AddEsia<TEsiaEvents>(EsiaDefaults.AuthenticationScheme, _ => { });
 
         public static AuthenticationBuilder AddEsia(this AuthenticationBuilder builder, Action<EsiaOptions> configureOptions)
             => builder.AddEsia(EsiaDefaults.AuthenticationScheme, configureOptions);
 
         public static AuthenticationBuilder AddEsia<TEsiaEvents>(this AuthenticationBuilder builder, Action<EsiaOptions> configureOptions)
-            where TEsiaEvents : EsiaEvents
+            where TEsiaEvents : OpenIdConnectEvents
             => builder.AddEsia<TEsiaEvents>(EsiaDefaults.AuthenticationScheme, configureOptions);
 
         public static AuthenticationBuilder AddEsia(this AuthenticationBuilder builder, string authenticationScheme, Action<EsiaOptions> configureOptions)
             => builder.AddEsia(authenticationScheme, EsiaDefaults.DisplayName, configureOptions);
 
         public static AuthenticationBuilder AddEsia<TEsiaEvents>(this AuthenticationBuilder builder, string authenticationScheme, Action<EsiaOptions> configureOptions)
-            where TEsiaEvents : EsiaEvents
+            where TEsiaEvents : OpenIdConnectEvents
             => builder.AddEsia<TEsiaEvents>(authenticationScheme, EsiaDefaults.DisplayName, configureOptions);
 
         public static AuthenticationBuilder AddEsia(this AuthenticationBuilder builder, string authenticationScheme, string displayName, Action<EsiaOptions> configureOptions)
@@ -43,7 +43,7 @@ namespace Microsoft.Extensions.DependencyInjection
             string authenticationScheme,
             string displayName,
             Action<EsiaOptions> configureOptions)
-            where TEsiaEvents : EsiaEvents
+            where TEsiaEvents : OpenIdConnectEvents
         {
             var esiaOptions = new EsiaOptions();
             configureOptions(esiaOptions);

--- a/src/OpenIdConnectOptionsBuilder.cs
+++ b/src/OpenIdConnectOptionsBuilder.cs
@@ -21,7 +21,9 @@ namespace AISGorod.AspNetCore.Authentication.Esia
             this.environment = environment;
         }
 
-        public Action<OpenIdConnectOptions> BuildAction()
+        public Action<OpenIdConnectOptions> BuildAction() => BuildAction<EsiaEvents>();
+
+        public Action<OpenIdConnectOptions> BuildAction<TEsiaEvents>() where TEsiaEvents : EsiaEvents
         {
             return (OpenIdConnectOptions options) =>
             {
@@ -37,7 +39,7 @@ namespace AISGorod.AspNetCore.Authentication.Esia
                 options.ClientId = esiaOptions.Mnemonic;
                 options.GetClaimsFromUserInfoEndpoint = false;
                 options.StateDataFormat = new EsiaSecureDataFormat();
-                options.EventsType = typeof(EsiaEvents);
+                options.EventsType = typeof(TEsiaEvents);
                 _FillScopes(options.Scope);
                 options.SignInScheme = esiaOptions.SignInScheme;
                 options.SignOutScheme = esiaOptions.SignOutScheme;

--- a/src/OpenIdConnectOptionsBuilder.cs
+++ b/src/OpenIdConnectOptionsBuilder.cs
@@ -23,7 +23,7 @@ namespace AISGorod.AspNetCore.Authentication.Esia
 
         public Action<OpenIdConnectOptions> BuildAction() => BuildAction<EsiaEvents>();
 
-        public Action<OpenIdConnectOptions> BuildAction<TEsiaEvents>() where TEsiaEvents : EsiaEvents
+        public Action<OpenIdConnectOptions> BuildAction<TEsiaEvents>() where TEsiaEvents : OpenIdConnectEvents
         {
             return (OpenIdConnectOptions options) =>
             {


### PR DESCRIPTION
Добавление возможности зарегестрировать кастомный `OpenIdConnectEvents`, а также возможность унаследоваться от уже существующего `EsiaEvents`. Внесенные изменения позволяют добавлять дополнительные параметры в первый редирект в ЕСИА, а также, к примеру, переопределить механизм редиректа, если он отличается (требуется при интеграции с Цифровым Профилем).