### PR TITLE
Disable nonce

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: csharp
 solution: Esia.sln
 mono: none
-dotnet: 3.1.403
+dotnet: 6.0.403
 script:
   - dotnet build

--- a/samples/EsiaSample/EsiaSample.csproj
+++ b/samples/EsiaSample/EsiaSample.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/AISGorod.AspNetCore.Authentication.Esia.csproj
+++ b/src/AISGorod.AspNetCore.Authentication.Esia.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFrameworks>netcoreapp3.1;net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -16,7 +16,7 @@
 ESIA (gosuslugi) identity provider (middleware) for ASP.NET Core based on OpenID Connect.</Description>
     <PackageReleaseNotes>https://github.com/AISGorod/AISGorod.AspNetCore.Authentication.Esia/releases/</PackageReleaseNotes>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
-    <Version>1.4.0</Version>
+    <Version>1.5.0-preview1</Version>
     <PackageIcon>icon.png</PackageIcon>
   </PropertyGroup>
 
@@ -25,8 +25,12 @@ ESIA (gosuslugi) identity provider (middleware) for ASP.NET Core based on OpenID
     <None Include="icon.png" Pack="true" PackagePath="" />
   </ItemGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="3.1.2" />
+  <ItemGroup Condition = "'$(TargetFramework)' == 'netcoreapp3.1'">
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="3.1.31" />
+  </ItemGroup>
+  <ItemGroup Condition = "'$(TargetFramework)' == 'net6.0'">
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="6.0.11" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
   </ItemGroup>
 
 </Project>

--- a/src/EsiaHandler.cs
+++ b/src/EsiaHandler.cs
@@ -2,14 +2,6 @@
 using Microsoft.AspNetCore.Authentication.OpenIdConnect;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
-using Microsoft.IdentityModel.Protocols.OpenIdConnect;
-using Newtonsoft.Json.Linq;
-using System;
-using System.Collections.Generic;
-using System.Globalization;
-using System.Net.Http;
-using System.Net.Http.Headers;
-using System.Text;
 using System.Text.Encodings.Web;
 using System.Threading.Tasks;
 

--- a/src/OpenIdConnectOptionsBuilder.cs
+++ b/src/OpenIdConnectOptionsBuilder.cs
@@ -38,6 +38,7 @@ namespace AISGorod.AspNetCore.Authentication.Esia
                 options.TokenValidationParameters.ValidIssuer = "http://esia.gosuslugi.ru/";
                 options.SecurityTokenValidator = esiaOptions.SecurityTokenValidator;
                 options.ClientId = esiaOptions.Mnemonic;
+                options.ProtocolValidator.RequireNonce = false;
                 options.GetClaimsFromUserInfoEndpoint = false;
                 options.StateDataFormat = new EsiaSecureDataFormat();
                 options.EventsType = typeof(TEsiaEvents);


### PR DESCRIPTION
С 16 ноября ЕСИА не возвращает nonce в id_token.

Также надо обновить пакеты до net6.0, т.к. netcoreapp3.1 уже не актуальна.