### PR TITLE
Добавлено получение данных о контактных данных, адресах и документах во время входа через ЕСИА

### DIFF
--- a/src/EsiaDefaults.cs
+++ b/src/EsiaDefaults.cs
@@ -29,5 +29,15 @@
         /// Тип claim для контактных данных ФЛ.
         /// </summary>
         public const string PrnsCttsClaimType = "urn:esia:prns:ctts";
+
+        /// <summary>
+        /// Тип claim для адресов ФЛ.
+        /// </summary>
+        public const string PrnsAddrsClaimType = "urn:esia:prns:addrs";
+
+        /// <summary>
+        /// Тип claim для документов ФЛ.
+        /// </summary>
+        public const string PrnsDocsClaimType = "urn:esia:prns:docs";
     }
 }

--- a/src/EsiaDefaults.cs
+++ b/src/EsiaDefaults.cs
@@ -24,5 +24,10 @@
         /// Имя HTTP-клиента для работы REST API.
         /// </summary>
         public const string RestClientHttpName = "Esia.RestClient";
+
+        /// <summary>
+        /// Тип claim для контактных данных ФЛ.
+        /// </summary>
+        public const string PrnsCttsClaimType = "urn:esia:prns:ctts";
     }
 }

--- a/src/EsiaExceptions.cs
+++ b/src/EsiaExceptions.cs
@@ -1,0 +1,13 @@
+﻿using System;
+
+namespace AISGorod.AspNetCore.Authentication.Esia;
+
+/// <summary>
+/// Ошибка запроса к REST API ЕСИА.
+/// </summary>
+internal class EsiaRestRequestException : Exception
+{
+    public EsiaRestRequestException(string? message, Exception? innerException) : base(message, innerException)
+    {
+    }
+}

--- a/src/EsiaExtensions.cs
+++ b/src/EsiaExtensions.cs
@@ -56,7 +56,8 @@ namespace Microsoft.Extensions.DependencyInjection
         {
             var esiaOptions = new EsiaOptions();
             configureOptions(esiaOptions);
-            IEsiaEnvironment esiaEnvironment = esiaOptions.EnvironmentInstance;
+            IEsiaEnvironment esiaEnvironment = esiaOptions.EnvironmentInstance
+                ?? new EsiaEnvironmentResolver(esiaOptions.Environment ?? throw new ArgumentNullException("Environment and EnvironmentInstance is null")).Resolve();
 
             // register new services
             builder.Services.AddSingleton(esiaOptions);

--- a/src/EsiaOptions.cs
+++ b/src/EsiaOptions.cs
@@ -59,6 +59,11 @@ namespace AISGorod.AspNetCore.Authentication.Esia
         public bool SaveTokens { get; set; }
 
         /// <summary>
+        /// Запрашивает и сохраняет в claims с типом <see cref="EsiaDefaults.PrnsCttsClaimType"/> сведения о контактных данных ФЛ.
+        /// </summary>
+        public bool GetContactsOnSignIn { get; set; }
+
+        /// <summary>
         /// Валидатор маркера доступа.
         /// Значение по умолчанию - валидатор JwtSecurityTokenHandler.
         /// </summary>

--- a/src/EsiaOptions.cs
+++ b/src/EsiaOptions.cs
@@ -61,7 +61,17 @@ namespace AISGorod.AspNetCore.Authentication.Esia
         /// <summary>
         /// Запрашивает и сохраняет в claims с типом <see cref="EsiaDefaults.PrnsCttsClaimType"/> сведения о контактных данных ФЛ.
         /// </summary>
-        public bool GetContactsOnSignIn { get; set; }
+        public bool GetPrnsContactInformationOnSignIn { get; set; }
+
+        /// <summary>
+        /// Запрашивает и сохраняет в claims с типом <see cref="EsiaDefaults.PrnsAddrsClaimType"/> сведения об адресах ФЛ.
+        /// </summary>
+        public bool GetPrnsAddressesOnSignIn { get; set; }
+
+        /// <summary>
+        /// Запрашивает и сохраняет в claims с типом <see cref="EsiaDefaults.PrnsDocsClaimType"/> сведения о документах ФЛ.
+        /// </summary>
+        public bool GetPrnsDocumentsOnSignIn { get; set; }
 
         /// <summary>
         /// Валидатор маркера доступа.


### PR DESCRIPTION
В `EsiaOptions` добавлены параметры `GetPrnsContactInformationOnSignIn`, `GetPrnsAddressesOnSignIn` и `GetPrnsDocumentsOnSignIn`.
Теперь при из использовании в момент входа запрашиваются данные от REST API ЕСИА и складываются в claim c соответствующими типами.